### PR TITLE
Use older libhybris, fix compositor.

### DIFF
--- a/recipes-core/libhybris/libhybris/0001-Disable-wifi-module.patch
+++ b/recipes-core/libhybris/libhybris/0001-Disable-wifi-module.patch
@@ -1,0 +1,65 @@
+From 7c9fa12d1f5feaaddb9e3d3a6e5a8352eb980942 Mon Sep 17 00:00:00 2001
+From: Florent Revest <revestflo@gmail.com>
+Date: Sat, 21 Oct 2017 21:12:33 +0200
+Subject: [PATCH] Disable wifi module
+
+---
+ hybris/Makefile.am       |  2 +-
+ hybris/configure.ac      |  2 --
+ hybris/tests/Makefile.am | 10 +---------
+ 3 files changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/hybris/Makefile.am b/hybris/Makefile.am
+index 906140e..fc6a786 100644
+--- a/hybris/Makefile.am
++++ b/hybris/Makefile.am
+@@ -6,7 +6,7 @@ endif
+ if HAS_ANDROID_5_0_0
+ SUBDIRS += libsync
+ endif
+-SUBDIRS += egl glesv1 glesv2 ui sf input camera vibrator media wifi
++SUBDIRS += egl glesv1 glesv2 ui sf input camera vibrator media
+ 
+ if HAS_LIBNFC_NXP_HEADERS
+ SUBDIRS += libnfc_nxp libnfc_ndef_nxp
+diff --git a/hybris/configure.ac b/hybris/configure.ac
+index 8015754..c498ebd 100644
+--- a/hybris/configure.ac
++++ b/hybris/configure.ac
+@@ -269,8 +269,6 @@ AC_CONFIG_FILES([
+ 	vibrator/libvibrator.pc
+ 	media/Makefile
+ 	media/libmedia.pc
+-	wifi/Makefile
+-	wifi/libwifi.pc
+ 	include/Makefile
+ 	input/Makefile
+ 	input/libis.pc
+diff --git a/hybris/tests/Makefile.am b/hybris/tests/Makefile.am
+index 43fb93c..625aa4b 100644
+--- a/hybris/tests/Makefile.am
++++ b/hybris/tests/Makefile.am
+@@ -11,8 +11,7 @@ bin_PROGRAMS = \
+ 	test_vibrator \
+ 	test_media \
+ 	test_recorder \
+-	test_gps \
+-	test_wifi
++	test_gps
+ 
+ if HAS_ANDROID_4_2_0
+ bin_PROGRAMS += test_hwcomposer
+@@ -210,10 +209,3 @@ test_vibrator_LDADD = \
+ 	$(top_builddir)/hardware/libhardware.la \
+ 	$(top_builddir)/vibrator/libvibrator.la
+ 
+-test_wifi_SOURCES = test_wifi.c
+-test_wifi_CFLAGS = \
+-	-I$(top_srcdir)/include \
+-	$(ANDROID_HEADERS_CFLAGS)
+-test_wifi_LDADD = \
+-	$(top_builddir)/wifi/libwifi.la
+-
+-- 
+2.14.2
+

--- a/recipes-core/libhybris/libhybris_git.bbappend
+++ b/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,1 +1,5 @@
+FILESEXTRAPATHS_prepend_tetra := "${THISDIR}/libhybris:"
+SRCREV_tetra = "4aa3379de1d911f00a86cb5643f7ff63dd48d7a6"
+SRC_URI_append_tetra = " file://0001-Disable-wifi-module.patch;striplevel=2"
+
 EXTRA_OECONF_append_tetra = " --enable-experimental"

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0001-Adapt-to-what-tetra-s-hwcomposer-expects.patch
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0001-Adapt-to-what-tetra-s-hwcomposer-expects.patch
@@ -1,4 +1,4 @@
-From 16a863cd2af8e957d045baf3bc8d8d8f7a96298c Mon Sep 17 00:00:00 2001
+From 6c7a9d9b54bad4737b9efa56b87251cbee83fe55 Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Tue, 17 Oct 2017 19:21:51 +0200
 Subject: [PATCH] Adapt to what tetra's hwcomposer expects
@@ -8,7 +8,7 @@ Subject: [PATCH] Adapt to what tetra's hwcomposer expects
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
-index 26ee1cc..d7c20bc 100644
+index 1db55ff..c2ebcae 100644
 --- a/hwcomposer/hwcomposer_backend_v11.cpp
 +++ b/hwcomposer/hwcomposer_backend_v11.cpp
 @@ -118,18 +118,18 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
@@ -43,7 +43,7 @@ index 26ee1cc..d7c20bc 100644
  
      if (mlist[0]->retireFenceFd != -1) {
          close(mlist[0]->retireFenceFd);
-@@ -291,7 +291,7 @@ HwComposerBackend_v11::createWindow(int width, int height)
+@@ -292,7 +292,7 @@ HwComposerBackend_v11::createWindow(int width, int height)
  
  
      HWComposer *hwc_win = new HWComposer(width, height, HAL_PIXEL_FORMAT_RGBA_8888,
@@ -52,15 +52,15 @@ index 26ee1cc..d7c20bc 100644
      return (EGLNativeWindowType) static_cast<ANativeWindow *>(hwc_win);
  }
  
-@@ -345,7 +345,7 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
-     } else {
+@@ -385,7 +385,7 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
+ 
  #ifdef HWC_DEVICE_API_VERSION_1_4
          if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
 -            HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_NORMAL));
-+//            HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_NORMAL));
++            //HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_NORMAL));
          } else
  #endif
  #ifdef HWC_DEVICE_API_VERSION_1_5
 -- 
-2.7.4
+2.29.0
 


### PR DESCRIPTION
Something in the current `libhybris` makes tetra fail to boot. After lots of debugging the only working version is the 1.0 release. It is possible that more recent versions of `libhybris` work. But this is time consuming. Will try to look into the exact issue, which commit in `libhybris` is to blame for this.

https://github.com/AsteroidOS/asteroid/issues/100 describes the error trace. Looking at that trace would imply that the error is either in `glib-2.0`, `qtbase` or `qt5-qpa-hwcomposer-plugin`. After rolling those back to what they were on the 1.0 release, the issue still exists.

There was an issue with `qt5-qpa-hwcomposer-plugin`, but that happens later in the boot process. (https://github.com/AsteroidOS/meta-asteroid/pull/51)

This fixes https://github.com/AsteroidOS/asteroid/issues/123, fixes https://github.com/AsteroidOS/meta-tetra-hybris/issues/8 and fixes https://github.com/AsteroidOS/asteroid/issues/100