### PR TITLE
Fix real installation issue (by building sparse images at build too).

### DIFF
--- a/recipes-core/images/asteroid-image.bbappend
+++ b/recipes-core/images/asteroid-image.bbappend
@@ -1,0 +1,8 @@
+DEPENDS_append_tetra = " android-simg2img-native "
+
+generate_sparse_image() {
+    img2simg "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ext4" "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.simg"
+    ln -s "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.simg" "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.simg"
+}
+
+IMAGE_POSTPROCESS_COMMAND_append_tetra = " generate_sparse_image "

--- a/recipes-devtools/android-simg2img/android-simg2img_git.bb
+++ b/recipes-devtools/android-simg2img/android-simg2img_git.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Tool to convert Android sparse images"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://img2simg.cpp;beginline=1;endline=15;md5=69dd3a3cbb50842da4c61d01ee32f421"
+
+SRC_URI = "git://github.com/AsteroidOS/android-simg2img.git;protocol=https"
+SRCREV = "25866381ea14caffec1d069d4226793b2d28a6a2"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 755 append2simg ${D}${bindir}/
+    install -m 755 img2simg ${D}${bindir}/
+    install -m 755 simg2img ${D}${bindir}/
+    install -m 755 simg2simg ${D}${bindir}/
+    install -m 755 simg_dump.py ${D}${bindir}/
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
It seems that the existing `ext2simg` produces broken sparse images. While flashing is successful, it results in missing files on the partition eventually causing a bootloop.

This PR makes it such that a replacement to the aforementioned tool is used: `img2simg`.
But this tool creates sparse images with the raw and fill chunk types. The latter is not supported by the tetra bootloader, this results in a fastboot error: `FAILED (remote: unknown chunk type in sparse image)`
My solution to this is to only create a sparse image that contains raw chunks. This seems to work well with the tetra bootloader.

This work generates a sparse image during the build process, as such a change to the installation instructions is required such that users can download the sparse image from there instead of creating it themselves.

This fixes https://github.com/AsteroidOS/asteroid/issues/161.
